### PR TITLE
GitHub URL

### DIFF
--- a/module.json
+++ b/module.json
@@ -7,7 +7,7 @@
     "humhub": {
         "minVersion": "1.16"
     },
-    "homepage": "https://github.com/humhub/virus-scanner",
+    "homepage": "https://github.com/humhub/online-users",
     "authors": [
         {
             "name": "Lucas Bartholemy"

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
     "id": "online-users",
-    "name": "Online users",
+    "name": "Online Users",
     "description": "The module displays online users directly on your dashboard in a snippet.",
     "keywords": ["online", "users", "snippet"],
     "version": "1.0.0",


### PR DESCRIPTION
Wrong GitHub URL in mdoule.json

&

To be consistent with other modules, I've capitalized the letters in the module name.